### PR TITLE
Adding EMNIST full dataset

### DIFF
--- a/fedtorch/comms/trainings/federated/afl.py
+++ b/fedtorch/comms/trainings/federated/afl.py
@@ -99,6 +99,12 @@ def train_and_validate_federated_afl(client):
 
                         # load data
                         _input, _target = load_data_batch(client.args, _input, _target, tracker)
+
+                        # Skip batches with one sample because of BatchNorm issue in some models!
+                        if _input.size(0)==1:
+                            is_sync = is_sync_fed(client.args)
+                            break
+                        
                         # inference and get current performance.
                         client.optimizer.zero_grad()
                         loss, performance = inference(client.model, client.criterion, client.metrics, _input, _target)

--- a/fedtorch/comms/trainings/federated/apfl.py
+++ b/fedtorch/comms/trainings/federated/apfl.py
@@ -86,6 +86,11 @@ def train_and_validate_federated_apfl(client):
 
                         # load data
                         _input, _target = load_data_batch(client.args, _input, _target, tracker)
+                        # Skip batches with one sample because of BatchNorm issue in some models!
+                        if _input.size(0)==1:
+                            is_sync = is_sync_fed(client.args)
+                            break
+
                         # inference and get current performance.
                         client.optimizer.zero_grad()
                         loss, performance = inference(client.model, client.criterion, client.metrics, _input, _target)

--- a/fedtorch/comms/utils/eval.py
+++ b/fedtorch/comms/utils/eval.py
@@ -84,6 +84,10 @@ def do_validate(args,
         # load data and check performance.
         _input, _target = _load_data_batch(args, _input, _target)
 
+        # Skip batches with one sample because of BatchNorm issue in some models!
+        if _input.size(0)==1:
+            break
+
         with torch.no_grad():
             if personal:
                 loss, performance = inference_personal(

--- a/fedtorch/components/dataset.py
+++ b/fedtorch/components/dataset.py
@@ -95,14 +95,14 @@ def partition_dataset(args, shuffle, dataset_type, Partitioner=None, return_part
     # partition data.
     if args.partition_data and dataset_type == 'train':
         if args.iid_data:
-            if args.data in ['emnist','synthetic','shakespeare']:
+            if args.data in ['emnist', 'emnist_full','synthetic','shakespeare']:
                 raise ValueError('The dataset {} does not have a structure for iid distribution of data'.format(args.data))
             if args.growing_batch_size:
                 pt = 'growing'
             else:
                 pt = 'normal'
         else:
-            if args.data not in ['mnist','fashion_mnist','emnist','cifar10','cifar100','adult','synthetic','shakespeare']:
+            if args.data not in ['mnist','fashion_mnist','emnist', 'emnist_full','cifar10','cifar100','adult','synthetic','shakespeare']:
                     raise NotImplementedError("""Non-iid distribution of data for dataset {} is not implemented.
                         Set the distribution to iid.""".format(args.data))
             if args.growing_batch_size:
@@ -167,12 +167,12 @@ def partition_dataset(args, shuffle, dataset_type, Partitioner=None, return_part
 
         # Generate validation data part
         if args.fed_personal:
-            if args.data in ['emnist','shakespeare']:
+            if args.data in ['emnist', 'emnist_full', 'shakespeare']:
                 data_to_load_train = data_to_load
                 data_to_load_val = get_dataset(args, args.data, args.data_dir, split='val')
             
             if args.federated_type == "perfedavg":
-                if args.data in ['emnist','shakespeare']:
+                if args.data in ['emnist', 'emnist_full', 'shakespeare']:
                     #TODO: make this size a paramter
                     val_size = int(0.1*len(data_to_load))
                     data_to_load_train, data_to_load_val1 = torch.utils.data.random_split(data_to_load,[len(data_to_load) - val_size, val_size])
@@ -185,7 +185,7 @@ def partition_dataset(args, shuffle, dataset_type, Partitioner=None, return_part
                                     num_workers=5, pin_memory=args.pin_memory,
                                     drop_last=False)
             else:
-                if args.data not in ['emnist','shakespeare']:
+                if args.data not in ['emnist', 'emnist_full', 'shakespeare']:
                     val_size = int(0.2*len(data_to_load))
                     data_to_load_train, data_to_load_val = torch.utils.data.random_split(data_to_load,[len(data_to_load) - val_size, val_size])
             # Generate data loaders

--- a/fedtorch/components/datasets/partition.py
+++ b/fedtorch/components/datasets/partition.py
@@ -115,6 +115,7 @@ class FederatedPartitioner(Partitioner):
 
         # If data is synthetic, the chunk of each client is decided beforehand.
         if args.data == 'synthetic':
+            # TODO: Merge with emnist and shakespeare datasets
             # self.partitions = [[] for _ in range(args.graph.n_nodes)]
             # indices = data.indices
             # # self.check_indices(indices)
@@ -124,7 +125,7 @@ class FederatedPartitioner(Partitioner):
             #     self.partitions[args.graph.rank].extend(list(range(from_index, to_index)))
             self.partitions = [[] for _ in range(args.graph.n_nodes)]
             self.partitions[args.graph.rank].extend(list(range(len(self.data))))
-        elif args.data in ['emnist','shakespeare']:
+        elif args.data in ['emnist', 'emnist_full', 'shakespeare']:
             self.partitions = [[] for _ in range(args.graph.n_nodes)]
             self.partitions[args.graph.rank].extend(list(range(len(self.data))))
         elif args.data == 'adult':

--- a/fedtorch/components/models/convex/logistic_regression.py
+++ b/fedtorch/components/models/convex/logistic_regression.py
@@ -25,7 +25,7 @@ class LogisticRegression(torch.nn.Module):
     def forward(self, x):
         # We don't need the softmax layer here since CrossEntropyLoss already
         # uses it internally.
-        if self.dataset in ['mnist', 'cifar10', 'cifar100', 'fashion_mnist','emnist']:
+        if self.dataset in ['mnist', 'cifar10', 'cifar100', 'fashion_mnist','emnist', 'emnist_full']:
             x = x.view(-1, self.num_features)
 
         x = self.fc(x)
@@ -50,6 +50,9 @@ class LogisticRegression(torch.nn.Module):
         elif self.dataset == 'emnist':
             self.num_features = 784
             self.num_classes = 10
+        elif self.dataset == 'emnist_full':
+            self.num_features = 784
+            self.num_classes = 62
         elif self.dataset == 'cifar10':
             self.num_features = 3072
             self.num_classes = 10

--- a/fedtorch/components/models/convex/robust_logistic_regression.py
+++ b/fedtorch/components/models/convex/robust_logistic_regression.py
@@ -26,7 +26,7 @@ class RobustLogisticRegression(torch.nn.Module):
     def forward(self, x):
         # We don't need the softmax layer here since CrossEntropyLoss already
         # uses it internally.
-        if self.dataset in ['mnist', 'cifar10', 'cifar100', 'fashion_mnist','emnist']:
+        if self.dataset in ['mnist', 'cifar10', 'cifar100', 'fashion_mnist','emnist', 'emnist_full']:
             x = x.view(-1, self.num_features)
 
         x = self.fc(x + self.noise)
@@ -51,6 +51,9 @@ class RobustLogisticRegression(torch.nn.Module):
         elif self.dataset == 'emnist':
             self.num_features = 784
             self.num_classes = 10
+        elif self.dataset == 'emnist_full':
+            self.num_features = 784
+            self.num_classes = 62
         elif self.dataset == 'cifar10':
             self.num_features = 3072
             self.num_classes = 10

--- a/fedtorch/components/models/nonconvex/cnn.py
+++ b/fedtorch/components/models/nonconvex/cnn.py
@@ -25,7 +25,7 @@ class CNN(nn.Module):
     def _decide_num_channels(self):
         if self.dataset in ['cifar10', 'cifar100']:
             return 3
-        elif self.dataset in ['mnist','fashion_mnist','emnist']:
+        elif self.dataset in ['mnist','fashion_mnist','emnist', 'emnist_full']:
             return 1
 
     def _decide_num_classes(self):
@@ -33,6 +33,8 @@ class CNN(nn.Module):
             return 10
         elif self.dataset == 'cifar100':
             return 100
+        elif self.dataset == 'emnist_full':
+            return 62
 
     def _decide_input_feature_size(self):
         if 'mnist' in self.dataset:

--- a/fedtorch/components/models/nonconvex/mlp.py
+++ b/fedtorch/components/models/nonconvex/mlp.py
@@ -34,6 +34,8 @@ class MLP(nn.Module):
             return 10
         elif self.dataset == 'cifar100':
             return 100
+        elif self.dataset == 'emnist_full':
+            return 62
         elif self.dataset == 'adult':
             return 2
 

--- a/fedtorch/components/models/nonconvex/robust_mlp.py
+++ b/fedtorch/components/models/nonconvex/robust_mlp.py
@@ -35,6 +35,8 @@ class RobustMLP(nn.Module):
             return 10
         elif self.dataset == 'cifar100':
             return 100
+        elif self.dataset == 'emnist_full':
+            return 62
         elif self.dataset == 'adult':
             return 2
 

--- a/fedtorch/nodes/nodes_centered.py
+++ b/fedtorch/nodes/nodes_centered.py
@@ -66,7 +66,7 @@ class ClientCentered(Node):
             param.data = ref_param.data
     
     def load_local_dataset(self,Partitioner):
-        if self.args.data in ['emnist','synthetic','shakespeare']:
+        if self.args.data in ['emnist', 'emnist_full', 'synthetic','shakespeare']:
             if self.args.fed_personal:
                 if self.args.federated_type == 'perfedavg':
                     self.train_loader, self.test_loader, self.val_loader,  self.val_loader1 = define_dataset(self.args, shuffle=True, test=False)

--- a/fedtorch/parameters.py
+++ b/fedtorch/parameters.py
@@ -21,7 +21,10 @@ def get_args():
     # add arguments.
     # dataset.
     parser.add_argument('-d', '--data', default='cifar10',
-                        help='a specific dataset name')
+                        choices=['cifar10','cifar100','mnist','fashion_mnist',
+                            'emnist','emnist_full', 'synthetic', 'shakespeare','adult',
+                            'epsilon','MSD', 'higgs', 'rcv1', 'stl10'],
+                        help='Dataset name.')
     parser.add_argument('-p', '--data_dir', default='./data/',
                         help='path to dataset')
     parser.add_argument('--partition_data', default=True, type=str2bool,

--- a/main_centered.py
+++ b/main_centered.py
@@ -19,7 +19,7 @@ def main(args):
     # Create Clients and the Server
     ClientNodes ={}
     for i in range(args.num_workers):
-        if args.data in ['emnist','synthetic'] or i==0:
+        if args.data in ['emnist', 'emnist_full','synthetic'] or i==0:
             ClientNodes[i] = ClientCentered(args,i)
         else:
             ClientNodes[i] = ClientCentered(args,i, Partitioner=ClientNodes[0].Partitioner)

--- a/run_mpi.py
+++ b/run_mpi.py
@@ -6,13 +6,14 @@ def main(args):
     model={'epsilon':'logistic_regression', 
            'MSD':'robust_least_square', 
            'cifar10':'logistic_regression', 
-           'emnist':'mlp', 
+           'emnist':'mlp',
+           'emnist_full':'mlp', 
            'mnist':'mlp',
            'synthetic':'logistic_regression',
            'fashion_mnist':'mlp',
            'adult':'logistic_regression'}
     
-    mlp_size = {'mnist':200,'fashion_mnist':200,'cifar10':200,'cifar100':500,'adult':50,'MSD':50,'emnist':200}
+    mlp_size = {'mnist':200,'fashion_mnist':200,'cifar10':200,'cifar100':500,'adult':50,'MSD':50,'emnist':200, 'emnist_full':200}
     NUM_NODES=1
     NUM_WORKER_PER_NODE =  int(args.num_clients / NUM_NODES)
     NUM_WORKERS_NODE = [NUM_WORKER_PER_NODE] * NUM_NODES 


### PR DESCRIPTION
Adding EMNIST full dataset in addition to its digits_only version, which was implemented before. Now, we have `emnist` and `emnist_full` datasets. The `emnist` dataset has 3383 clients with 10 classes, but the `emnist_full` has 3400 clients with 62 classes. Resolve the Batch Norm issue for training with 1 sample in the batch.